### PR TITLE
Remove time offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 _wakatime_exporter_ is a Prometheus exporter for Wakatime statistics. It intends to extend the existing Wakatime ecosystem via allowing users to make use of Prometheus (and therefore any consumers of its API) as companion services alongside the traditional Wakatime web application. This could be anything from including some of your coding statistics in Grafana, to forecasting your coding time with prophet. Sky's the limit!
 
-> NOTE: _wakatime_exporter_ is currently in  ALPHA. Expect things to break and change.
+> NOTE: _wakatime_exporter_ is currently in ALPHA. Expect things to break and change.
 
 [Click here](METRICS.md) to see an example of the exported metrics.
 
@@ -29,8 +29,8 @@ _wakatime_exporter_ is a Prometheus exporter for Wakatime statistics. It intends
 
 ## Usage
 
-In most cases, you should only need to provide an API key and a time offset (see below for details).
-All other parameters are for advanced use-cases only and you should be able to leave them as their defaults.
+In most cases, you should only need to provide an API key.
+All other parameters are for advanced use-cases only and you should be able to leave them set to their defaults.
 
 You can get your Wakatime API key by visiting: https://wakatime.com/api-key
 
@@ -47,7 +47,6 @@ Flags:
                                        Base path to query for Wakatime data.
   --wakatime.user="current"            User to query for Wakatime data.
   --wakatime.api-key=WAKATIME.API-KEY  Token to use when getting stats from Wakatime.
-  --wakatime.t-offset=0s               Time offset (from UTC) for managing Wakatime dates.
   --wakatime.timeout=5s                Timeout for trying to get stats from Wakatime.
   --wakatime.ssl-verify                Flag that enables SSL certificate verification.
   --log.level=info                     Only log messages with the given severity or above.
@@ -65,7 +64,6 @@ WAKA_METRICS_PATH="/metrics"                  # Path under which to expose metri
 WAKA_SCRAPE_URI="https://wakatime.com/api/v1" # Base path to query for Wakatime data.
 WAKA_USER="current"                           # User to query for Wakatime data.
 WAKA_API_KEY=""                               # Token to use when getting stats from Wakatime.
-WAKA_TIME_OFFSET="0s"                         # Time offset (from UTC) for managing Wakatime dates.
 WAKA_TIMEOUT="5s"                             # Timeout for trying to get stats from Wakatime.
 WAKA_SSL_VERIFY="true"                        # SSL certificate verification for the scrape URI.
 ```
@@ -75,12 +73,3 @@ WAKA_SSL_VERIFY="true"                        # SSL certificate verification for
 ```shell
 docker run -p 9212:9212 macropower/wakatime-exporter:0.0.4 --wakatime.api-key="YOUR_API_KEY"
 ```
-
-## Time zones
-
-Wakatime will use whatever timezone you have set in your preferences to choose what date to append new metrics to. For instance, a timezone of America/New_York results in the local date changing at 4AM UTC. This exporter, by default, will begin to query the next date at 12AM UTC. This will lead to innacuracies in the data, as the final hours (4 hours, in this case) will not be reported.
-
-**Thus, you must take _one_ of the following two actions to receive correct data:**
-
-- Set the `--wakatime.t-offset` parameter to adjust when the exporter begins querying the new date. For instance, since America/New_York is UTC−04:00, you can supply `-4h` to obtain correct results. This parameter accepts both positive and negative values.
-- Change your timezone in your Wakatime preferences to `UTC` at: https://wakatime.com/settings/preferences

--- a/collectors/alltime/main.go
+++ b/collectors/alltime/main.go
@@ -48,8 +48,8 @@ var (
 type Exporter exporter.Exporter
 
 // NewExporter creates the Summary exporter
-func NewExporter(baseURI *url.URL, user string, token string, sslVerify bool, tzOffset time.Duration, timeout time.Duration, logger log.Logger) *Exporter {
-	var fetchStat func(url.URL, string, string) (io.ReadCloser, error)
+func NewExporter(baseURI *url.URL, user string, token string, sslVerify bool, timeout time.Duration, logger log.Logger) *Exporter {
+	var fetchStat func(url.URL, string) (io.ReadCloser, error)
 	fetchStat = exporter.FetchHTTP(token, sslVerify, timeout, logger)
 
 	return &Exporter{
@@ -57,7 +57,6 @@ func NewExporter(baseURI *url.URL, user string, token string, sslVerify bool, tz
 		Endpoint:  endpoint,
 		User:      user,
 		FetchStat: fetchStat,
-		TZOffset:  tzOffset,
 		Up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
@@ -120,11 +119,9 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) error {
 
 	e.TotalScrapes.Inc()
 
-	dateUTC := exporter.GetDate(e.TZOffset)
 	userURL := exporter.UserPath(e.URI, e.User)
 
-	body, fetchErr := e.FetchStat(userURL, dateUTC, endpoint)
-	defer body.Close()
+	body, fetchErr := e.FetchStat(userURL, endpoint)
 	if fetchErr != nil {
 		return fetchErr
 	}
@@ -134,6 +131,8 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) error {
 	if err != nil {
 		return err
 	}
+
+	defer body.Close()
 
 	level.Info(e.Logger).Log(
 		"msg", "Collecting all time from Wakatime",

--- a/lib/types.go
+++ b/lib/types.go
@@ -23,18 +23,17 @@ import (
 	"io"
 	"net/url"
 	"sync"
-	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// Exporter is a struct for all collector exporters
 type Exporter struct {
 	URI            *url.URL
 	Endpoint, User string
 	Mutex          sync.RWMutex
-	FetchStat      func(url.URL, string, string) (io.ReadCloser, error)
-	TZOffset       time.Duration
+	FetchStat      func(url.URL, string) (io.ReadCloser, error)
 
 	Up                          prometheus.Gauge
 	TotalScrapes, QueryFailures prometheus.Counter

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -62,24 +62,19 @@ func BoolToBinary(b bool) string {
 }
 
 // FetchHTTP is a generic fetch method for Wakatime API endpoints
-func FetchHTTP(token string, sslVerify bool, timeout time.Duration, logger log.Logger) func(uri url.URL, dateUTC string, subPath string) (io.ReadCloser, error) {
+func FetchHTTP(token string, sslVerify bool, timeout time.Duration, logger log.Logger) func(uri url.URL, subPath string) (io.ReadCloser, error) {
 	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: !sslVerify}}
 	client := http.Client{
 		Timeout:   timeout,
 		Transport: tr,
 	}
 	sEnc := b64.StdEncoding.EncodeToString([]byte(token))
-	return func(uri url.URL, dateUTC string, subPath string) (io.ReadCloser, error) {
-		level.Info(logger).Log("msg", "Scraping Wakatime", "date", dateUTC, "path", subPath)
-
-		params := url.Values{}
-		params.Add("start", dateUTC)
-		params.Add("end", dateUTC)
+	return func(uri url.URL, subPath string) (io.ReadCloser, error) {
 
 		uri.Path = path.Join(uri.Path, subPath)
-		uri.RawQuery = params.Encode()
-
 		url := uri.String()
+
+		level.Info(logger).Log("msg", "Scraping Wakatime", "path", subPath, "url", url)
 
 		req, err := http.NewRequest(http.MethodGet, url, nil)
 		if err != nil {
@@ -118,11 +113,6 @@ func ReadAndUnmarshal(body io.ReadCloser, object interface{}) error {
 	}
 
 	return nil
-}
-
-// GetDate applies any offsets and returns the current YYYY-MM-DD date
-func GetDate(offset time.Duration) string {
-	return time.Now().UTC().Add(offset).Format("2006-01-02")
 }
 
 // UserPath appends the User path to a given URL

--- a/main.go
+++ b/main.go
@@ -45,7 +45,6 @@ func main() {
 		wakaScrapeURI = kingpin.Flag("wakatime.scrape-uri", "Base path to query for Wakatime data.").Default("https://wakatime.com/api/v1").Envar("WAKA_SCRAPE_URI").String()
 		wakaUser      = kingpin.Flag("wakatime.user", "User to query for Wakatime data.").Default("current").Envar("WAKA_USER").String()
 		wakaToken     = kingpin.Flag("wakatime.api-key", "Token to use when getting stats from Wakatime.").Required().Envar("WAKA_API_KEY").String()
-		wakaOffset    = kingpin.Flag("wakatime.t-offset", "Time offset (from UTC) for managing Wakatime dates.").Default("0s").Envar("WAKA_TIME_OFFSET").Duration()
 		wakaTimeout   = kingpin.Flag("wakatime.timeout", "Timeout for trying to get stats from Wakatime.").Default("5s").Envar("WAKA_TIMEOUT").Duration()
 		wakaSSLVerify = kingpin.Flag("wakatime.ssl-verify", "Flag that enables SSL certificate verification for the scrape URI.").Default("true").Envar("WAKA_SSL_VERIFY").Bool()
 	)
@@ -67,10 +66,10 @@ func main() {
 	}
 
 	exporter := version.NewCollector("wakatime_exporter")
-	summaryExporter := summary.NewExporter(wakaBaseURI, *wakaUser, *wakaToken, *wakaSSLVerify, *wakaOffset, *wakaTimeout, logger)
-	leaderExporter := leader.NewExporter(wakaBaseURI, *wakaUser, *wakaToken, *wakaSSLVerify, *wakaOffset, *wakaTimeout, logger)
-	goalExporter := goal.NewExporter(wakaBaseURI, *wakaUser, *wakaToken, *wakaSSLVerify, *wakaOffset, *wakaTimeout, logger)
-	alltimeExporter := alltime.NewExporter(wakaBaseURI, *wakaUser, *wakaToken, *wakaSSLVerify, *wakaOffset, *wakaTimeout, logger)
+	summaryExporter := summary.NewExporter(wakaBaseURI, *wakaUser, *wakaToken, *wakaSSLVerify, *wakaTimeout, logger)
+	leaderExporter := leader.NewExporter(wakaBaseURI, *wakaUser, *wakaToken, *wakaSSLVerify, *wakaTimeout, logger)
+	goalExporter := goal.NewExporter(wakaBaseURI, *wakaUser, *wakaToken, *wakaSSLVerify, *wakaTimeout, logger)
+	alltimeExporter := alltime.NewExporter(wakaBaseURI, *wakaUser, *wakaToken, *wakaSSLVerify, *wakaTimeout, logger)
 
 	prometheus.MustRegister(exporter, summaryExporter, leaderExporter, goalExporter, alltimeExporter)
 


### PR DESCRIPTION
This wasn't well documented, but I discovered that you can pass the string "today" into wakatime queries to get the current date. This should remove the need to manage time locally.